### PR TITLE
Replace mcrypt with openssl for PHP 7.1 compatibility

### DIFF
--- a/corp/crypto/DingtalkCrypt.php
+++ b/corp/crypto/DingtalkCrypt.php
@@ -11,7 +11,7 @@ class DingtalkCrypt
 	private $m_suiteKey;
 
 	
-	public function DingtalkCrypt($token, $encodingAesKey, $suiteKey)
+	public function __construct($token, $encodingAesKey, $suiteKey)
 	{
 		$this->m_token = $token;
 		$this->m_encodingAesKey = $encodingAesKey;

--- a/isv/crypto/DingtalkCrypt.php
+++ b/isv/crypto/DingtalkCrypt.php
@@ -11,7 +11,7 @@ class DingtalkCrypt
 	private $m_suiteKey;
 
 	
-	public function DingtalkCrypt($token, $encodingAesKey, $suiteKey)
+	public function __construct($token, $encodingAesKey, $suiteKey)
 	{
 		$this->m_token = $token;
 		$this->m_encodingAesKey = $encodingAesKey;


### PR DESCRIPTION
[mcrypt has been deprecated in PHP 7.1 ](http://php.net/manual/en/migration71.deprecated.php)
The modified crypto module has been tested on PHP 7.1.2 and PHP 5.6.30