### PR TITLE
增加 https 的默认的 443 端口号的隐藏

### DIFF
--- a/corp/api/Auth.php
+++ b/corp/api/Auth.php
@@ -48,7 +48,7 @@ class Auth
         }
         $pageURL .= "://";
 
-        if ($_SERVER["SERVER_PORT"] != "80")
+        if ($_SERVER["SERVER_PORT"] != "80" && ($pageURL == "https://" && $_SERVER["SERVER_PORT"] != "443"))
         {
             $pageURL .= $_SERVER["SERVER_NAME"] . ":" . $_SERVER["SERVER_PORT"] . $_SERVER["REQUEST_URI"];
         }


### PR DESCRIPTION
否则会导致生成的 signature 验证不通过。